### PR TITLE
Remove a missing depend "·".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>Menu · District Records Office</title>
+  <title>Menu - District Records Office</title>
   <link rel="icon" href="/images/DRO-logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>


### PR DESCRIPTION
The icon "·" is not supported via HTML, I also declared the universal language for HTML using <html lang="en"> so that won't throw errors.